### PR TITLE
Silverstripe Admin CMS Fix

### DIFF
--- a/nginx-ssl-proxy.conf
+++ b/nginx-ssl-proxy.conf
@@ -11,10 +11,19 @@ server {
     ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
     ssl_prefer_server_ciphers on;
 
-    proxy_connect_timeout       600;
-    proxy_send_timeout          600;
-    proxy_read_timeout          600;
     send_timeout                600;
+
+    # Needed to support Silverstripe CMS
+    fastcgi_buffer_size 128k;
+    fastcgi_buffers 4 256k;
+    fastcgi_busy_buffers_size 256k;
+    proxy_connect_timeout 90;
+    proxy_send_timeout 180;
+    proxy_read_timeout 180;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
+    proxy_intercept_errors on;
 
     location / {
         proxy_set_header        Host $host;


### PR DESCRIPTION
The SilverStripe admin CMS was throwing an error (Bad Gateway) when trying to retrieve data via AJAX.

The server was returning the private IP address which nginx was proxying and causing 404 errors when the client tried to access the private IP instead of the nginx proxy.

This fixes the issue and allows admin CMS access on local development machines.